### PR TITLE
Stopped freshmen from signing their own packets

### DIFF
--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -11,7 +11,12 @@ class SignaturesController < ApplicationController
         if upperclassman_signed_in? and not Signature.exists?(freshman: freshman, signer: @current_upperclassman)
           Signature.create(freshman: freshman, signer: @current_upperclassman)
         elsif freshman_signed_in? and not Signature.exists?(freshman: freshman, signer: @current_freshman)
-          Signature.create(freshman: freshman, signer: @current_freshman)
+          if freshman == @current_freshman
+            # If freshman attempts to sign own packet
+            flash[:error] = "You cannot sign your own packet"
+          else
+            # If freshman attemps to sign other freshman's packet
+            Signature.create(freshman: freshman, signer: @current_freshman)
         else
           flash[:error] = "Unable to sign packet"
         end


### PR DESCRIPTION
Before, freshmen could sign their own packets. With this change (hopefully), they won't be able to, because of the if/else statement that checks whether or not the freshman signed in is the same as the freshman whose packet is about to be signed. 
